### PR TITLE
Disable product button

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -7,9 +7,6 @@ const ui = require('./ui.js')
 const onSignUp = (event) => {
   event.preventDefault()
   const formData = getFormFields(event.target)
-  console.log('this is the form data')
-  console.log(formData)
-
   api.signUp(formData)
   // Auto sign-up to sign-in.
     .then(() => { onSignUpSignIn(formData) })
@@ -26,8 +23,6 @@ const onSignUpSignIn = (formData) => {
 const onSignIn = (event) => {
   event.preventDefault()
   const formData = getFormFields(event.target)
-  console.log('this is the form data')
-  console.log(formData)
   api.signIn(formData)
     .then(ui.signInSuccess)
     .catch(ui.authFailure)

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -1,6 +1,7 @@
 'use strict'
 const store = require('../store')
 const toast = require('../templates/toast')
+const purchaseApi = require('../purchases/api')
 
 // Save the user info to store, reset form fields, and hide modal.
 const signInSuccess = (responseData) => {
@@ -9,6 +10,20 @@ const signInSuccess = (responseData) => {
   // Display success message, unhide secured items and hide unsecured items.
   toast.success('Sign in successful. Welcome to Nile, ' + store.user.email)
   authRefresh()
+
+  // Run the getCart api request and add the user's cart to the store file. Then
+  // loop through each of the items in the cart using the item ID. For each
+  // item ID in the cart, disable the 'Add to Cart' button, to prevent the user
+  // from adding the same product into the cart.
+  purchaseApi.getCart()
+    .then((cartResponse) => {
+      store.cart = cartResponse.cart
+      const openCartItems = store.cart.items.map(item => item._id)
+      for (let i = 0; i < openCartItems.length; i++) {
+        const eachItem = i
+        $('.btn-target-' + openCartItems[eachItem]).hide()
+      }
+    })
 }
 
 // Used for both sign up and sign in failure. display message, then reset form fields.

--- a/assets/scripts/purchases/events.js
+++ b/assets/scripts/purchases/events.js
@@ -26,7 +26,7 @@ const removeFromCart = (event) => {
   event.preventDefault()
   const productId = $(event.target).data('id')
   api.removeItem(productId)
-    .then(ui.removeItemSuccess)
+    .then((responseData) => ui.removeItemSuccess(responseData, productId))
     .catch(ui.removeItemFailure)
 }
 

--- a/assets/scripts/purchases/ui.js
+++ b/assets/scripts/purchases/ui.js
@@ -15,6 +15,8 @@ const cartFailure = (responseData) => {
 }
 
 const addItemSuccess = (responseData) => {
+  const addedProductId = responseData.cart.items.slice(-1)[0]
+  $('.btn-target-' + addedProductId).hide()
   toast.success('Item added to cart')
 }
 
@@ -22,8 +24,9 @@ const addItemFailure = (responseData) => {
   toast.failure('Unable to add item')
 }
 
-const removeItemSuccess = (responseData) => {
+const removeItemSuccess = (responseData, productId) => {
   toast.success('Item removed from cart')
+  $('.btn-target-' + productId).show()
   $('.modal').modal('hide')
   $('#nav-cart-button').trigger('click')
 }

--- a/assets/scripts/templates/product.hbs
+++ b/assets/scripts/templates/product.hbs
@@ -11,7 +11,7 @@
       <span class="item-price">{{product.price}}</span>
     </div>
     <div class="add-item">
-      <button class="btn btn-outline-primary" data-id="{{product._id}}">Add to Cart</button>
+      <button class="btn btn-outline-primary btn-target-{{product._id}}" data-id="{{product._id}}">Add to Cart</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Add automatic hide / show of 'Add to Cart' button
    
    -  Add functionality so that if a user signs in and already has items
    in their cart from a previous session, the 'Add to Cart' buttons for
    those items already in the cart are disabled (hidden), until that item
    is removed from the cart or a purchase is made.

   - Still showing 500 error on sign-up, because it checks for cart information and it is not there yet.